### PR TITLE
Improve DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Gem Version](https://badge.fury.io/rb/yabeda.svg)](https://rubygems.org/gems/yabeda) [![Build Status](https://travis-ci.org/yabeda-rb/yabeda.svg?branch=master)](https://travis-ci.org/yabeda-rb/yabeda)
 
-**This software is Work in Progress: features will appear and disappear, API will be changed, your feedback is always welcome!** 
+**This software is Work in Progress: features will appear and disappear, API will be changed, your feedback is always welcome!**
 
 Extendable solution for easy setup of monitoring in your Ruby apps.
 
@@ -32,35 +32,38 @@ And then execute:
 
     ```ruby
     Yabeda.configure do
-      group :your_app
-    
-      counter   :bells_rang_count, comment: "Total number of bells being rang"
-      gauge     :whistles_active,  comment: "Number of whistles ready to whistle"
-      histogram :whistle_runtime,  comment: "How long whistles are being active", unit: :seconds
+      group :your_app do
+        counter   :bells_rang_count, comment: "Total number of bells being rang"
+        gauge     :whistles_active,  comment: "Number of whistles ready to whistle"
+        histogram :whistle_runtime do
+          comment "How long whistles are being active"
+          unit :seconds
+        end
+      end
     end
     ```
-    
+
  2. Access metric in your app and use it!
- 
+
     ```ruby
     def ring_the_bell(id)
       bell = Bell.find(id)
       bell.ring!
-      Yabeda.your_app_bells_rang_count.increment({bell_size: bell.size}, by: 1)
+      Yabeda.your_app.bells_rang_count.increment({bell_size: bell.size}, by: 1)
     end
 
     def whistle!
-      Yabeda.your_app_whistle_runtime.measure do
+      Yabeda.your_app.whistle_runtime.measure do
         # Run your code
       end
     end
     ```
-    
+
  3. Setup collecting of metrics that do not tied to specific events in you application. E.g.: reporting your app's current state
     ```ruby
     Yabeda.configure do
       # This block will be executed periodically few times in a minute
-      # (by timer or external request depending on adapter you're using) 
+      # (by timer or external request depending on adapter you're using)
       # Keep it fast and simple!
       collect do
         your_app_whistles_active.set({}, Whistle.where(state: :active).count
@@ -74,7 +77,7 @@ And then execute:
 ## Roadmap (aka TODO or Help wanted)
 
  - Ability to change metric settings for individual adapters
- 
+
    ```rb
    histogram :foo, comment: "say what?" do
      adapter :prometheus do
@@ -82,9 +85,9 @@ And then execute:
      end
    end
    ```
-   
+
  - Ability to route some metrics only for given adapter:
- 
+
    ```rb
    adapter :prometheus do
      include_group :sidekiq

--- a/lib/yabeda.rb
+++ b/lib/yabeda.rb
@@ -15,6 +15,11 @@ module Yabeda
       @metrics ||= Concurrent::Hash.new
     end
 
+    # @return [Hash<String, Yabeda::Group>] All registered metrics
+    def groups
+      @groups ||= Concurrent::Hash.new
+    end
+
     # @return [Hash<String, Yabeda::BaseAdapter>] All loaded adapters
     def adapters
       @adapters ||= Concurrent::Hash.new

--- a/lib/yabeda/dsl.rb
+++ b/lib/yabeda/dsl.rb
@@ -1,65 +1,12 @@
 # frozen_string_literal: true
 
-require "yabeda/metric"
-require "yabeda/counter"
-require "yabeda/gauge"
-require "yabeda/histogram"
+require "yabeda/dsl/class_methods"
 
 module Yabeda
   # DSL for ease of work with Yabeda
   module DSL
     def self.included(base)
-      base.extend ClassMethods
+      base.extend DSL::ClassMethods
     end
-
-    # rubocop: disable Style/Documentation
-    module ClassMethods
-      # Block for grouping and simplifying configuration of related metrics
-      def configure(&block)
-        class_exec(&block)
-        @group = nil
-      end
-
-      # Define the actions that should be performed
-      def collect(&block)
-        ::Yabeda.collectors.push(block)
-      end
-
-      # Specify metric category or group for all consecutive metrics in this
-      # +configure+ block.
-      # On most adapters it is only adds prefix to the metric name but on some
-      # (like NewRelic) it is treated individually and have special meaning.
-      def group(group_name)
-        @group = group_name
-      end
-
-      # Register a growing-only counter
-      def counter(*args, **kwargs)
-        register(Counter.new(*args, **kwargs, group: @group))
-      end
-
-      # Register a gauge
-      def gauge(*args, **kwargs)
-        register(Gauge.new(*args, **kwargs, group: @group))
-      end
-
-      # Register an histogram
-      def histogram(*args, **kwargs)
-        register(Histogram.new(*args, **kwargs, group: @group))
-      end
-
-      private
-
-      def register(metric)
-        name = [metric.group, metric.name].compact.join("_")
-        ::Yabeda.define_singleton_method(name) { metric }
-        ::Yabeda.metrics[name] = metric
-        ::Yabeda.adapters.each do |_, adapter|
-          adapter.register!(metric)
-        end
-        metric
-      end
-    end
-    # rubocop: enable Style/Documentation
   end
 end

--- a/lib/yabeda/dsl/class_methods.rb
+++ b/lib/yabeda/dsl/class_methods.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "yabeda/metric"
+require "yabeda/counter"
+require "yabeda/gauge"
+require "yabeda/histogram"
+require "yabeda/group"
+require "yabeda/dsl/metric_builder"
+
+module Yabeda
+  # DSL for ease of work with Yabeda
+  module DSL
+    # rubocop: disable Style/Documentation
+    module ClassMethods
+      # Block for grouping and simplifying configuration of related metrics
+      def configure(&block)
+        class_exec(&block)
+        @group = nil
+      end
+
+      # Define the actions that should be performed
+      def collect(&block)
+        ::Yabeda.collectors.push(block)
+      end
+
+      # Specify metric category or group for all consecutive metrics in this
+      # +configure+ block.
+      # On most adapters it is only adds prefix to the metric name but on some
+      # (like NewRelic) it is treated individually and has a special meaning.
+      def group(group_name)
+        @group = group_name
+        return unless block_given?
+
+        yield
+        @group = nil
+      end
+
+      # Register a growing-only counter
+      def counter(*args, **kwargs, &block)
+        metric = MetricBuilder.new(Counter).build(args, kwargs, @group, &block)
+        register_metric(metric)
+      end
+
+      # Register a gauge
+      def gauge(*args, **kwargs, &block)
+        metric = MetricBuilder.new(Gauge).build(args, kwargs, @group, &block)
+        register_metric(metric)
+      end
+
+      # Register a histogram
+      def histogram(*args, **kwargs, &block)
+        metric = MetricBuilder.new(Histogram).build(args, kwargs, @group, &block)
+        register_metric(metric)
+      end
+
+      private
+
+      def register_metric(metric)
+        name = [metric.group, metric.name].compact.join("_")
+        ::Yabeda.define_singleton_method(name) { metric }
+        ::Yabeda.metrics[name] = metric
+        ::Yabeda.adapters.each_value { |adapter| adapter.register!(metric) }
+        register_group_for(metric) if metric.group
+        metric
+      end
+
+      def register_group_for(metric)
+        group = ::Yabeda.groups[metric.group]
+
+        if group.nil?
+          group = Group.new(metric.group)
+          ::Yabeda.groups[metric.group] = group
+          ::Yabeda.define_singleton_method(metric.group) { group }
+        end
+
+        group.register_metric(metric)
+      end
+    end
+    # rubocop: enable Style/Documentation
+  end
+end

--- a/lib/yabeda/dsl/metric_builder.rb
+++ b/lib/yabeda/dsl/metric_builder.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "yabeda/dsl/option_builder"
+
+module Yabeda
+  class ConfigurationError < StandardError; end
+
+  module DSL
+    # Handles DSL for working with individual metrics
+    class MetricBuilder
+      extend Dry::Initializer
+
+      param :metric_klass
+
+      def build(args, kwargs, group, &block)
+        options = OptionBuilder.new(metric_klass, kwargs).options_from(&block)
+        initialize_metric(args, options, group)
+      end
+
+      private
+
+      def initialize_metric(params, options, group)
+        metric_klass.new(*params, **options, group: group)
+      rescue KeyError => error
+        raise ConfigurationError, "#{error.message} for #{metric_klass.name}"
+      end
+    end
+  end
+end

--- a/lib/yabeda/dsl/option_builder.rb
+++ b/lib/yabeda/dsl/option_builder.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Yabeda
+  module DSL
+    # Collects options for metric initializer
+    class OptionBuilder
+      extend Dry::Initializer
+
+      param :metric_klass
+      param :options
+
+      def options_from(&block)
+        instance_eval(&block) if block
+
+        return options if unknown_options.empty?
+
+        raise ConfigurationError,
+              "option '#{unknown_options.first}' is not available for #{metric_klass.name}"
+      end
+
+      def method_missing(method_name, method_args, &_block)
+        if kwarg?(method_name)
+          options[method_name] = method_args
+        else
+          super
+        end
+      end
+
+      def respond_to_missing?(method_name, _args)
+        kwarg?(method_name) || super
+      end
+
+      private
+
+      def kwarg?(method_name)
+        option_names.include?(method_name.to_sym)
+      end
+
+      def option_names
+        definitions = metric_klass.dry_initializer.definitions.values
+        definitions.select(&:option).map { |definition| definition.source.to_sym }
+      end
+
+      def unknown_options
+        options.keys - option_names
+      end
+    end
+  end
+end

--- a/lib/yabeda/group.rb
+++ b/lib/yabeda/group.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "dry-initializer"
+
+module Yabeda
+  # Represents a set of metrics grouped under the same name
+  class Group
+    extend Dry::Initializer
+
+    param :name
+
+    def register_metric(metric)
+      define_singleton_method(metric.name) { metric }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,8 @@ RSpec.configure do |config|
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
 
+  config.order = :random
+
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end

--- a/spec/yabeda/dsl/class_methods_spec.rb
+++ b/spec/yabeda/dsl/class_methods_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+RSpec.describe Yabeda::DSL::ClassMethods do
+  after do
+    if Yabeda.instance_variable_defined?(:@groups)
+      Yabeda.instance_variable_get(:@groups).keys.each do |group|
+        Yabeda.singleton_class.send(:remove_method, group)
+      end
+      Yabeda.remove_instance_variable(:@groups)
+    end
+
+    if Yabeda.instance_variable_defined?(:@metrics)
+      Yabeda.instance_variable_get(:@metrics).keys.each do |metric|
+        Yabeda.singleton_class.send(:remove_method, metric)
+      end
+      Yabeda.remove_instance_variable(:@metrics)
+    end
+  end
+
+  describe ".group" do
+    context "without block" do
+      before do
+        Yabeda.configure do
+          group :group1
+          gauge :test_gauge
+
+          group :group2
+          histogram :test_histogram, buckets: [1, 10, 100]
+        end
+      end
+
+      it "defines metric method on the root object" do
+        expect(Yabeda.group1_test_gauge).to be_a(Yabeda::Gauge)
+        expect(Yabeda.group2_test_histogram).to be_a(Yabeda::Histogram)
+      end
+
+      it "defines group methods on the root object" do
+        expect(Yabeda.group1).to be_a(Yabeda::Group)
+        expect(Yabeda.group2).to be_a(Yabeda::Group)
+      end
+
+      it "defines methods on the group objects" do
+        expect(Yabeda.group1.test_gauge).to be_a(Yabeda::Gauge)
+        expect(Yabeda.group2.test_histogram).to be_a(Yabeda::Histogram)
+      end
+    end
+
+    context "with block" do
+      before do
+        Yabeda.configure do
+          group(:group1) { gauge(:test_gauge) }
+          histogram(:test_histogram, buckets: [1, 10, 100])
+        end
+      end
+
+      it "defines metric method on the root object" do
+        expect(Yabeda.group1_test_gauge).to be_a(Yabeda::Gauge)
+      end
+
+      it "not attaches metric to a previous group" do
+        expect(Yabeda.test_histogram).to be_a(Yabeda::Histogram)
+      end
+
+      it "defines group methods on the root object" do
+        expect(Yabeda.group1).to be_a(Yabeda::Group)
+      end
+
+      it "defines methods on the group objects" do
+        expect(Yabeda.group1.test_gauge).to be_a(Yabeda::Gauge)
+      end
+    end
+  end
+
+  describe ".counter" do
+    subject { Yabeda.test_counter }
+
+    context "when properly configured" do
+      before do
+        Yabeda.configure { counter(:test_counter) }
+      end
+
+      it("defines method on root object") { is_expected.to be_a(Yabeda::Counter) }
+    end
+  end
+
+  describe ".gauge" do
+    subject { Yabeda.test_gauge }
+
+    context "when properly configured" do
+      before do
+        Yabeda.configure { gauge(:test_gauge) }
+      end
+
+      it("defines method on root object") { is_expected.to be_a(Yabeda::Gauge) }
+    end
+  end
+
+  describe ".histogram" do
+    subject { Yabeda.test_histogram }
+
+    context "when properly configured" do
+      before do
+        Yabeda.configure { histogram(:test_histogram, buckets: [1, 10, 100]) }
+      end
+
+      it("defines method on root object") { is_expected.to be_a(Yabeda::Histogram) }
+    end
+  end
+end

--- a/spec/yabeda/dsl/metric_builder_spec.rb
+++ b/spec/yabeda/dsl/metric_builder_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.describe Yabeda::DSL::MetricBuilder do
+  class TestMetric < Yabeda::Metric
+    option :required_option
+  end
+
+  subject(:metric) do
+    described_class.new(TestMetric).build(args, kwargs, group, &block)
+  end
+
+  let(:args) { [:test_metric] }
+  let(:kwargs) { { required_option: "value" } }
+  let(:group) { nil }
+  let(:block) { proc {} }
+
+  context "when required option is not provided" do
+    let(:kwargs) { {} }
+
+    it "raises error" do
+      expect { metric }.to raise_error(
+        Yabeda::ConfigurationError,
+        /option 'required_option' is required for TestMetric/,
+      )
+    end
+  end
+
+  context "when unknown option is provided" do
+    let(:kwargs) { { required_option: nil, buckets: [] } }
+
+    it "raises error" do
+      expect { metric }.to raise_error(
+        Yabeda::ConfigurationError,
+        /option 'buckets' is not available for TestMetric/,
+      )
+    end
+  end
+
+  context "when kwargs provided" do
+    it "assignes options" do
+      expect(metric).to have_attributes(required_option: "value")
+    end
+  end
+
+  context "when kwargs and block provided" do
+    let(:kwargs) { { comment: "comment" } }
+    let(:block) { proc { required_option "value" } }
+
+    it "merges options" do
+      expect(metric).to have_attributes(required_option: "value", comment: "comment")
+    end
+  end
+
+  context "when same option defined inside a block and in kwargs" do
+    let(:block) { proc { required_option "new_value" } }
+
+    it "overrides param value" do
+      expect(metric).to have_attributes(required_option: "new_value")
+    end
+  end
+
+  context "when group is provided" do
+    let(:group) { "group" }
+
+    it "assignes group" do
+      expect(metric).to have_attributes(group: group)
+    end
+  end
+end


### PR DESCRIPTION
Changes:

- ability to group metrics with blocks:

  ```ruby
  group :anycable do
    counter :rpc_executed_total
  end
  ```
- ability pass options to metrics with blocks:

  ```ruby
  histogram :rpc_runtime do
    buckets [0.1, 10, 100]
  end
  ```

- friendly error messages about unknown/required options (`option 'buckets' is required for Histogram`, `option 'wat' is not available for Histogram`)
- tests are run in the random order