### PR TITLE
add `yabeda-cloudwatch` to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ And then execute:
 These are developed and maintained by other awesome folks:
 
  - [Statsd](https://github.com/asusikov/yabeda-statsd)
+ - [AWS CloudWatch](https://github.com/retsef/yabeda-cloudwatch)
  - _…and more! You can write your own adapter and open a pull request to add it into this list._
 
 ## Available plugins to collect metrics


### PR DESCRIPTION
This gems adds the ability to register an adapter to send data directly to AWS CloudWatch