### PR TITLE
add `yabeda-shoryuken` to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ These are developed and maintained by other awesome folks:
  - [yabeda-gruf](https://github.com/Placewise/yabeda-gruf) — metrics for [gRPC Ruby Framework](https://github.com/bigcommerce/gruf)
  - [yabeda-gc](https://github.com/ianks/yabeda-gc) — metrics for Ruby garbage collection.
  - [yabeda-activejob](https://github.com/Fullscript/yabeda-activejob) — backend-agnostic metrics for background jobs.
+ - [yabeda-shoryuken](https://github.com/retsef/yabeda-shoryuken) — metrics for [Shoryuken](https://github.com/ruby-shoryuken/shoryuken) jobs execution message queues.
  - _…and more! You can write your own adapter and open a pull request to add it into this list._
 
 ## Configuration


### PR DESCRIPTION
This gems adds the ability to track metric of [Shoryuken](https://github.com/ruby-shoryuken/shoryuken) jobs execution stats. Heavy inspired by `yabeda-sidekiq`