### PR TITLE
Add yabeda-rack-ratelimit plugin to list of third-party plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ These are developed and maintained by other awesome folks:
  - [yabeda-gc](https://github.com/ianks/yabeda-gc) — metrics for Ruby garbage collection.
  - [yabeda-activejob](https://github.com/Fullscript/yabeda-activejob) — backend-agnostic metrics for background jobs.
  - [yabeda-shoryuken](https://github.com/retsef/yabeda-shoryuken) — metrics for [Shoryuken](https://github.com/ruby-shoryuken/shoryuken) jobs execution message queues.
+ - [yabeda-rack-ratelimit](https://github.com/basecamp/yabeda-rack-ratelimit) — metrics for [Rack::Ratelimit](https://github.com/jeremy/rack-ratelimit)
  - _…and more! You can write your own adapter and open a pull request to add it into this list._
 
 ## Configuration


### PR DESCRIPTION
We've just published https://github.com/basecamp/yabeda-rack-ratelimit which produces some metrics for [Rack::Ratelimit](https://github.com/jeremy/rack-ratelimit).