### PR TITLE
Add yabeda-honeybadger_insights to the list of adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ These are developed and maintained by other awesome folks:
 
  - [Statsd](https://github.com/asusikov/yabeda-statsd)
  - [AWS CloudWatch](https://github.com/retsef/yabeda-cloudwatch)
+ - [Honeybadger Insights](https://github.com/honeybadger-io/yabeda-honeybadger_insights)
  - _…and more! You can write your own adapter and open a pull request to add it into this list._
 
 ## Available plugins to collect metrics


### PR DESCRIPTION
This adds the ability to send metrics as events to [Honeybadger Insights](https://www.honeybadger.io/tour/logging-observability/).