### PR TITLE
fix: railtie loading to prevent calling methods that have not yet been defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   )
   ```
 
+### Fixed
+
+- Railtie loading to prevent calling methods that have not yet been defined
+
 ## 0.12.0 - 2023-07-28
 
 ### Added
@@ -48,7 +52,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Adapters now should use method `Yabeda.collect!` instead of manual calling of every collector block. 
+- Adapters now should use method `Yabeda.collect!` instead of manual calling of every collector block.
 
 ## 0.9.0 - 2021-05-07
 

--- a/lib/yabeda.rb
+++ b/lib/yabeda.rb
@@ -8,7 +8,6 @@ require "yabeda/config"
 require "yabeda/dsl"
 require "yabeda/tags"
 require "yabeda/errors"
-require "yabeda/railtie" if defined?(Rails)
 
 # Extendable framework for collecting and exporting metrics from Ruby apps
 module Yabeda
@@ -148,3 +147,5 @@ module Yabeda
     end
   end
 end
+
+require "yabeda/railtie" if defined?(Rails)


### PR DESCRIPTION
Hey!

In some cases (e.g., testing with optional dependencies) Yabeda may be loaded after a dummy Rails app is loaded. So, it as the common way to requre railties as late as possible.

```
NoMethodError:
  undefined method `already_configured?' for module Yabeda
# /usr/local/bundle/ruby/3.3.0/gems/yabeda-0.12.0/lib/yabeda/railtie.rb:7:in `block in <class:Railtie>'
# /usr/local/bundle/ruby/3.3.0/gems/activesupport-7.2.1/lib/active_support/lazy_load_hooks.rb:94:in `block in execute_hook'
# /usr/local/bundle/ruby/3.3.0/gems/activesupport-7.2.1/lib/active_support/lazy_load_hooks.rb:87:in `with_execution_control'
# /usr/local/bundle/ruby/3.3.0/gems/activesupport-7.2.1/lib/active_support/lazy_load_hooks.rb:92:in `execute_hook'
# /usr/local/bundle/ruby/3.3.0/gems/activesupport-7.2.1/lib/active_support/lazy_load_hooks.rb:62:in `block in on_load'
# /usr/local/bundle/ruby/3.3.0/gems/activesupport-7.2.1/lib/active_support/lazy_load_hooks.rb:61:in `each'
# /usr/local/bundle/ruby/3.3.0/gems/activesupport-7.2.1/lib/active_support/lazy_load_hooks.rb:61:in `on_load'
# /usr/local/bundle/ruby/3.3.0/gems/railties-7.2.1/lib/rails/railtie/configuration.rb:71:in `after_initialize'
# /usr/local/bundle/ruby/3.3.0/gems/yabeda-0.12.0/lib/yabeda/railtie.rb:6:in `<class:Railtie>'
# /usr/local/bundle/ruby/3.3.0/gems/yabeda-0.12.0/lib/yabeda/railtie.rb:5:in `<module:Rails>'
# /usr/local/bundle/ruby/3.3.0/gems/yabeda-0.12.0/lib/yabeda/railtie.rb:4:in `<module:Yabeda>'
# /usr/local/bundle/ruby/3.3.0/gems/yabeda-0.12.0/lib/yabeda/railtie.rb:3:in `<top (required)>'
# /usr/local/bundle/ruby/3.3.0/gems/zeitwerk-2.6.18/lib/zeitwerk/kernel.rb:34:in `require'
# /usr/local/bundle/ruby/3.3.0/gems/yabeda-0.12.0/lib/yabeda.rb:11:in `<top (required)>'
```