### PR TITLE
Expand functionality: limit group for adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,19 @@ Yabeda.configure do
 end
 ```
 
+Or use another DSL to describe this logic:
+
+```ruby
+Yabeda.configure do
+  group :mushrooms do
+    counter :champignon_counter
+  end
+
+  adapter :basket_adapter do
+    include_group :mushrooms
+  end
+end
+```
 
 ## Roadmap (aka TODO or Help wanted)
 

--- a/lib/yabeda/dsl/class_methods.rb
+++ b/lib/yabeda/dsl/class_methods.rb
@@ -96,10 +96,23 @@ module Yabeda
       #
       # @param adapter_names [Array<Symbol>] Names of adapters to use
       def adapter(*adapter_names, group: @group)
-        raise ConfigurationError, "Adapter limitation can't be defined outside of group" unless group
+        raise ConfigurationError, "Adapter limitation can't be defined without adapter_names" if adapter_names.empty?
+
+        @adapter_names = adapter_names
+        if group
+          include_group(group)
+        else
+          return yield if block_given?
+
+          raise ConfigurationError, "Should be block passed with call .include_group for example"
+        end
+      end
+
+      def include_group(group)
+        raise ConfigurationError, "Adapter limitation can't be defined without of group name" unless group
 
         Yabeda.groups[group] ||= Yabeda::Group.new(group)
-        Yabeda.groups[group].adapter(*adapter_names)
+        Yabeda.groups[group].adapter(*@adapter_names)
       end
 
       private

--- a/lib/yabeda/dsl/class_methods.rb
+++ b/lib/yabeda/dsl/class_methods.rb
@@ -104,8 +104,10 @@ module Yabeda
         else
           return yield if block_given?
 
-          raise ConfigurationError, "Should be block passed with call .include_group for example"
+          raise ConfigurationError, "Yabeda.adapter should be called either inside group declaration " \
+            "or should have block provided with a call to include_group. No metric group provided."
         end
+      ensure @adapter_names = nil
       end
 
       def include_group(group)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,8 +12,6 @@ RSpec.configure do |config|
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
 
-  config.order = :random
-
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,8 @@ RSpec.configure do |config|
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
 
+  config.order = :random
+
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end

--- a/spec/yabeda/counter_spec.rb
+++ b/spec/yabeda/counter_spec.rb
@@ -6,31 +6,25 @@ RSpec.describe Yabeda::Counter do
   let(:tags) { { foo: "bar" } }
   let(:metric_value) { 10 }
   let(:adapter) { instance_double(Yabeda::BaseAdapter, perform_counter_increment!: true, register!: true) }
+  let(:counter) { Yabeda.test_counter }
 
   before do
     Yabeda.register_adapter(:test_adapter, adapter)
+    Yabeda.configure do
+      counter :test_counter
+    end
+    Yabeda.configure! unless Yabeda.already_configured?
   end
 
-  context "when config has no group" do
-    let(:counter) { Yabeda.test_counter }
+  it { expect(increment_counter).to eq(metric_value) }
 
-    before do
-      Yabeda.configure do
-        counter :test_counter
-      end
-      Yabeda.configure! unless Yabeda.already_configured?
-    end
+  it "increments counter with empty tags if tags are not provided" do
+    expect { counter.increment }.to change { counter.values[{}] }.by(1)
+  end
 
-    it { expect(increment_counter).to eq(metric_value) }
-
-    it "increments counter with empty tags if tags are not provided" do
-      expect { counter.increment }.to change { counter.values[{}] }.by(1)
-    end
-
-    it "execute perform_counter_increment!" do
-      increment_counter
-      expect(adapter).to have_received(:perform_counter_increment!).with(counter, tags, metric_value)
-    end
+  it "execute perform_counter_increment!" do
+    increment_counter
+    expect(adapter).to have_received(:perform_counter_increment!).with(counter, tags, metric_value)
   end
 
   context "with adapter option" do

--- a/spec/yabeda/counter_spec.rb
+++ b/spec/yabeda/counter_spec.rb
@@ -2,52 +2,141 @@
 
 RSpec.describe Yabeda::Counter do
   subject(:increment_counter) { counter.increment(tags, by: metric_value) }
-
   let(:tags) { { foo: "bar" } }
   let(:metric_value) { 10 }
-  let(:counter) { Yabeda.test_counter }
-  let(:built_tags) { { built_foo: "built_bar" } }
   let(:adapter) { instance_double(Yabeda::BaseAdapter, perform_counter_increment!: true, register!: true) }
 
   before do
-    Yabeda.configure do
-      counter :test_counter
-    end
-    Yabeda.configure! unless Yabeda.already_configured?
-    allow(Yabeda::Tags).to receive(:build).with(tags, anything).and_return(built_tags)
-    allow(Yabeda::Tags).to receive(:build).with({}, anything).and_return({})
     Yabeda.register_adapter(:test_adapter, adapter)
   end
 
-  it { expect(increment_counter).to eq(metric_value) }
+  context "when config has no group" do
+    let(:counter) { Yabeda.test_counter }
 
-  it "increments counter with empty tags if tags are not provided" do
-    expect { counter.increment }.to change { counter.values[{}] }.by(1)
-  end
+    before do
+      Yabeda.configure do
+        counter :test_counter
+      end     
+      Yabeda.configure! unless Yabeda.already_configured?
+    end
 
-  it "execute perform_counter_increment! method of adapter" do
-    increment_counter
-    expect(adapter).to have_received(:perform_counter_increment!).with(counter, built_tags, metric_value)
+    it { expect(increment_counter).to eq(metric_value) }
+
+    it "increments counter with empty tags if tags are not provided" do
+      expect { counter.increment }.to change { counter.values[{}] }.by(1)
+    end
+
+    it "execute perform_counter_increment!" do
+      increment_counter
+      expect(adapter).to have_received(:perform_counter_increment!).with(counter, tags, metric_value)
+    end
   end
 
   context "with adapter option" do
-    let(:counter) { Yabeda.counter_with_adapter }
     let(:another_adapter) { instance_double(Yabeda::BaseAdapter, perform_counter_increment!: true, register!: true) }
+    let(:counter) { Yabeda.counter_with_adapter }
 
     before do
       Yabeda.register_adapter(:another_adapter, another_adapter)
+
       Yabeda.configure do
         counter :counter_with_adapter, adapter: :test_adapter
       end
       Yabeda.configure! unless Yabeda.already_configured?
     end
 
-    it "execute perform_counter_increment! method of adapter with name :test_adapter" do
+    it "execute perform_counter_increment! with name :test_adapter" do
       increment_counter
 
       aggregate_failures do
-        expect(adapter).to have_received(:perform_counter_increment!).with(counter, built_tags, metric_value)
+        expect(adapter).to have_received(:perform_counter_increment!).with(counter, tags, metric_value)
         expect(another_adapter).not_to have_received(:perform_counter_increment!)
+      end
+    end
+  end
+
+  context "with call .adapter method" do
+    let(:tags) { { type: "champignon" } }
+    let(:counter) { Yabeda.mushrooms.champignon_counter }
+    let(:basket_adapter) { instance_double(Yabeda::BaseAdapter, perform_counter_increment!: true, register!: true) }
+
+    before do
+      Yabeda.register_adapter(:basket_adapter, basket_adapter)
+    end
+
+    context "when call .adapter method in outside of group" do
+      before do
+        Yabeda.configure do
+          group :mushrooms do
+            counter :champignon_counter
+          end
+
+          adapter :basket_adapter do
+            include_group :mushrooms
+          end
+        end
+        Yabeda.configure! unless Yabeda.already_configured?
+      end
+
+      it "execute perform_counter_increment! with name :basket_adapter" do
+        increment_counter
+  
+        aggregate_failures do
+          expect(basket_adapter).to have_received(:perform_counter_increment!).with(counter, tags, metric_value)
+          expect(adapter).not_to have_received(:perform_counter_increment!)
+        end
+      end
+    end
+
+    context "when call .adapter_names without adapter_names args" do
+      it "raises an error" do
+        expect do
+          Yabeda.configure do
+            group :mushrooms do
+              counter :champignon_counter
+            end
+
+            adapter do
+              include_group :mushrooms
+            end
+          end
+          Yabeda.configure! unless Yabeda.already_configured?
+        end.to raise_error(Yabeda::ConfigurationError, "Adapter limitation can't be defined without adapter_names")
+      end
+    end
+
+    context "when call adapter method in inside of group" do
+      before do
+        Yabeda.configure do
+          group :mushrooms do
+            adapter :basket_adapter
+            counter :champignon_counter
+          end
+        end
+        Yabeda.configure! unless Yabeda.already_configured?
+      end
+
+      it "execute perform_counter_increment! with name :basket_adapter" do
+        increment_counter
+  
+        aggregate_failures do
+          expect(basket_adapter).to have_received(:perform_counter_increment!).with(counter, tags, metric_value)
+          expect(adapter).not_to have_received(:perform_counter_increment!)
+        end
+      end
+    end
+
+    context "when call .adapter_names without adapter_names args" do
+      it "raises an error" do
+        expect do
+          Yabeda.configure do
+            group :mushrooms do
+              adapter
+              counter :champignon_counter
+            end
+          end
+          Yabeda.configure! unless Yabeda.already_configured?
+        end.to raise_error(Yabeda::ConfigurationError, "Adapter limitation can't be defined without adapter_names")
       end
     end
   end

--- a/spec/yabeda/counter_spec.rb
+++ b/spec/yabeda/counter_spec.rb
@@ -59,6 +59,31 @@ RSpec.describe Yabeda::Counter do
       Yabeda.register_adapter(:basket_adapter, basket_adapter)
     end
 
+    it "raises an error using include_group construction without adapter_names args" do
+      expect do
+        Yabeda.configure do
+          group :mushrooms do
+            counter :champignon_counter
+          end
+
+          adapter { include_group :mushrooms }
+        end
+        Yabeda.configure! unless Yabeda.already_configured?
+      end.to raise_error(Yabeda::ConfigurationError, "Adapter limitation can't be defined without adapter_names")
+    end
+
+    it "raises an error using adapter construction into the group block without adapter_names args" do
+      expect do
+        Yabeda.configure do
+          group :mushrooms do
+            adapter
+            counter :champignon_counter
+          end
+        end
+        Yabeda.configure! unless Yabeda.already_configured?
+      end.to raise_error(Yabeda::ConfigurationError, "Adapter limitation can't be defined without adapter_names")
+    end
+
     context "when call .adapter method in outside of group" do
       before do
         Yabeda.configure do
@@ -80,33 +105,6 @@ RSpec.describe Yabeda::Counter do
           expect(basket_adapter).to have_received(:perform_counter_increment!).with(counter, tags, metric_value)
           expect(adapter).not_to have_received(:perform_counter_increment!)
         end
-      end
-    end
-
-    context "when call .adapter_names without adapter_names args" do
-      it "raises an error using include_group construction" do
-        expect do
-          Yabeda.configure do
-            group :mushrooms do
-              counter :champignon_counter
-            end
-
-            adapter { include_group :mushrooms }
-          end
-          Yabeda.configure! unless Yabeda.already_configured?
-        end.to raise_error(Yabeda::ConfigurationError, "Adapter limitation can't be defined without adapter_names")
-      end
-
-      it "raises an error using adapter construction into the group block" do
-        expect do
-          Yabeda.configure do
-            group :mushrooms do
-              adapter
-              counter :champignon_counter
-            end
-          end
-          Yabeda.configure! unless Yabeda.already_configured?
-        end.to raise_error(Yabeda::ConfigurationError, "Adapter limitation can't be defined without adapter_names")
       end
     end
 

--- a/spec/yabeda/dsl/class_methods_spec.rb
+++ b/spec/yabeda/dsl/class_methods_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe Yabeda::DSL::ClassMethods do
         expect do
           Yabeda.configure { adapter :test }
           Yabeda.configure! unless Yabeda.already_configured?
-        end.to raise_error(Yabeda::ConfigurationError, /can't be defined outside of group/)
+        end.to raise_error(Yabeda::ConfigurationError, "Should be block passed with call .include_group for example")
       end
     end
 

--- a/spec/yabeda/dsl/class_methods_spec.rb
+++ b/spec/yabeda/dsl/class_methods_spec.rb
@@ -189,10 +189,13 @@ RSpec.describe Yabeda::DSL::ClassMethods do
   describe ".adapter" do
     context "when group is not defined" do
       it "raises an error" do
+        error_message = "Yabeda.adapter should be called either inside group declaration " \
+          "or should have block provided with a call to include_group. No metric group provided."
+
         expect do
           Yabeda.configure { adapter :test }
           Yabeda.configure! unless Yabeda.already_configured?
-        end.to raise_error(Yabeda::ConfigurationError, "Should be block passed with call .include_group for example")
+        end.to raise_error(Yabeda::ConfigurationError, error_message)
       end
     end
 

--- a/spec/yabeda/group_spec.rb
+++ b/spec/yabeda/group_spec.rb
@@ -2,14 +2,9 @@
 
 RSpec.describe Yabeda::Group do
   let(:name) { nil }
-
   let(:group) { described_class.new(name) }
 
-  before do
-    Yabeda.groups[name] = group
-  end
-
-  after { Yabeda.reset! }
+  before { Yabeda.groups[name] = group }
 
   describe "default tags" do
     context "when on the top level group" do

--- a/spec/yabeda_spec.rb
+++ b/spec/yabeda_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Yabeda do
+  before { described_class.reset! }
+
   it "has a version number" do
     expect(Yabeda::VERSION).not_to be_nil
   end


### PR DESCRIPTION
Hey, @Envek. In continue my [PR](https://github.com/yabeda-rb/yabeda/pull/39). I want to extend the metrics limit functionality for the adapter.
```ruby
# current version:
Yabeda.configure do
  group :mushrooms do
    adapter :basket_adapter
    counter :champignon_counter
  end
end

# added version:
Yabeda.configure do
  group :mushrooms do
    counter :champignon_counter
  end

  adapter :basket_adapter do
    include_group :mushrooms
  end
end
```
But specs do randomly green or red. For example:
```
1) Yabeda::Counter when config has no group execute perform_counter_increment!
   Failure/Error: let(:counter) { Yabeda.test_counter }
   
   NoMethodError:
     undefined method `test_counter' for Yabeda:Module
   # ./spec/yabeda/counter_spec.rb:14:in `block (3 levels) in <top (required)>'
   # ./spec/yabeda/counter_spec.rb:4:in `block (2 levels) in <top (required)>'
   # ./spec/yabeda/counter_spec.rb:30:in `block (3 levels) in <top (required)>'
```
What do you think about this? Thanks.