### PR TITLE
Update README link to GitLab's Prometheus Ruby client fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ And then execute:
 
  - Prometheus:
    - [yabeda-prometheus](https://github.com/yabeda-rb/yabeda-prometheus) — wraps [official Ruby client for Prometheus](https://github.com/prometheus/client_ruby).
-   - [yabeda-prometheus-mmap](https://github.com/yabeda-rb/yabeda-prometheus-mmap) — wraps [GitLab's fork of Prometheus Ruby client](https://gitlab.com/gitlab-org/prometheus-client-mmap) which may work better for multi-process application servers.
+   - [yabeda-prometheus-mmap](https://github.com/yabeda-rb/yabeda-prometheus-mmap) — wraps [GitLab's fork of Prometheus Ruby client](https://gitlab.com/gitlab-org/ruby/gems/prometheus-client-mmap) which may work better for multi-process application servers.
  - [Datadog](https://github.com/yabeda-rb/yabeda-datadog)
  - [NewRelic](https://github.com/yabeda-rb/yabeda-newrelic)
 


### PR DESCRIPTION
Minor fix to avoid the redirect
from https://gitlab.com/gitlab-org/prometheus-client-mmap
to https://gitlab.com/gitlab-org/ruby/gems/prometheus-client-mmap

<img width="540" height="237" alt="Screenshot of Gitlab page saying Project 'gitlab-org/prometheus-client-mmap' was moved to 'gitlab-org/ruby/gems/prometheus-client-mmap'. Please update any links and bookmarks that may still have the old path" src="https://github.com/user-attachments/assets/e613c702-ddab-47e3-b5e7-838c60f70635" />
