### PR TITLE
Control which metrics and groups are exposed for a given group using either an allow-list (`only`) or a deny-list (`except`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,53 @@ Yabeda.configure do
 end
 ```
 
+## Filtering metrics
+
+You can control which metrics and groups are exposed for a given group using either an allow-list (`only`) or a deny-list (`except`).
+
+To permit only specific metrics for a group, use the `only` option:
+
+```ruby
+Yabeda.configure do
+  group :internal do
+    only :foo
+
+    counter :foo
+    gauge :bar
+  end
+end
+```
+
+To exclude certain metrics from a group, use the `except` option:
+
+```ruby
+Yabeda.configure do
+  group :internal do
+    adapter :prometheus
+
+    except :bar
+
+    counter :foo
+    gauge :bar
+  end
+end
+```
+
+This mechanism is especially useful for disabling unwanted metrics from third-party plugins.
+
+For example, [yabeda-activerecord](https://github.com/yabeda-rb/yabeda-activerecord) doesn't provide its own configuration to turn off metrics with high cardinality, such as `queries_total` and `query_duration`. You can disable them like this:
+
+```ruby
+require 'yabeda'
+require 'yabeda-activerecord'
+
+Yabeda.configure do
+  group :activerecord do
+    except :queries_total, :query_duration
+  end
+end
+```
+
 ## Roadmap (aka TODO or Help wanted)
 
  - Ability to change metric settings for individual adapters

--- a/lib/yabeda.rb
+++ b/lib/yabeda.rb
@@ -8,6 +8,7 @@ require "yabeda/config"
 require "yabeda/dsl"
 require "yabeda/tags"
 require "yabeda/errors"
+require "yabeda/null_adapter"
 
 # Extendable framework for collecting and exporting metrics from Ruby apps
 module Yabeda
@@ -32,7 +33,9 @@ module Yabeda
 
     # @return [Hash<Symbol, Yabeda::BaseAdapter>] All loaded adapters
     def adapters
-      @adapters ||= Concurrent::Hash.new
+      @adapters ||= Concurrent::Hash.new.tap do |hash|
+        hash[:null_adapter] = Yabeda::NullAdapter.new
+      end
     end
 
     # @return [Array<Proc>] All collectors for periodical retrieving of metrics
@@ -138,7 +141,7 @@ module Yabeda
     # @api private
     def reset!
       default_tags.clear
-      adapters.clear
+      @adapters = nil
       groups.each_key { |group| singleton_class.send(:remove_method, group) if group && respond_to?(group) }
       @groups = nil
       metrics.each_key { |metric| singleton_class.send(:remove_method, metric) if respond_to?(metric) }

--- a/lib/yabeda/dsl/class_methods.rb
+++ b/lib/yabeda/dsl/class_methods.rb
@@ -110,6 +110,26 @@ module Yabeda
       ensure @adapter_names = nil
       end
 
+      def only(*metric_names, group: @group)
+        if group
+          Yabeda.groups[group] ||= Yabeda::Group.new(group)
+          Yabeda.groups[group].only(*metric_names)
+        else
+          raise ConfigurationError, "Yabeda.only should be called either inside group declaration " \
+            "or should have group name provided. No metric group provided."
+        end
+      end
+
+      def except(*metric_names, group: @group)
+        if group
+          Yabeda.groups[group] ||= Yabeda::Group.new(group)
+          Yabeda.groups[group].except(*metric_names)
+        else
+          raise ConfigurationError, "Yabeda.except should be called either inside group declaration " \
+            "or should have group name provided. No metric group provided."
+        end
+      end
+
       def include_group(group)
         raise ConfigurationError, "Adapter limitation can't be defined without of group name" unless group
 

--- a/lib/yabeda/dsl/class_methods.rb
+++ b/lib/yabeda/dsl/class_methods.rb
@@ -12,6 +12,7 @@ require "yabeda/dsl/metric_builder"
 module Yabeda
   # DSL for ease of work with Yabeda
   module DSL
+    # rubocop:disable Metrics/ModuleLength
     module ClassMethods
       # Block for grouping and simplifying configuration of related metrics
       def configure(&block)
@@ -162,4 +163,5 @@ module Yabeda
       end
     end
   end
+  # rubocop:enable Metrics/ModuleLength
 end

--- a/lib/yabeda/group.rb
+++ b/lib/yabeda/group.rb
@@ -26,6 +26,20 @@ module Yabeda
       @adapter.push(*adapter_names)
     end
 
+    def only(*metric_names)
+      return @only_list if metric_names.empty?
+
+      @only_list ||= Concurrent::Array.new
+      @only_list.push(*metric_names.map(&:to_sym))
+    end
+
+    def except(*metric_names)
+      return @except_list if metric_names.empty?
+
+      @except_list ||= Concurrent::Array.new
+      @except_list.push(*metric_names.map(&:to_sym))
+    end
+
     def register_metric(metric)
       define_singleton_method(metric.name) { metric }
     end

--- a/lib/yabeda/metric.rb
+++ b/lib/yabeda/metric.rb
@@ -63,7 +63,7 @@ module Yabeda
 
       return group&.adapter if @adapter == Dry::Initializer::UNDEFINED
 
-      @adapter
+      super
     end
 
     # Atomically increment the stored value, assumed to be given all labels, including group labels

--- a/lib/yabeda/metric.rb
+++ b/lib/yabeda/metric.rb
@@ -52,12 +52,18 @@ module Yabeda
       end
     end
 
-    # Redefined option reader to get group-level adapter if not set on metric level
-    # @api private
+    # Redefined option reader to get null adapter if metric is excluded from the group or from the only list in group,
+    # group-level adapter if not set on metric level, and adapter on metric level if set
+    # @api privatee
     def adapter
-      return ::Yabeda.groups[group]&.adapter if @adapter == Dry::Initializer::UNDEFINED
+      group = ::Yabeda.groups[self.group]
 
-      super
+      return :null_adapter if group&.except&.include?(name.to_sym) ||
+                              (group&.only && !group.only.include?(name.to_sym))
+
+      return group&.adapter if @adapter == Dry::Initializer::UNDEFINED
+
+      @adapter
     end
 
     # Atomically increment the stored value, assumed to be given all labels, including group labels

--- a/lib/yabeda/null_adapter.rb
+++ b/lib/yabeda/null_adapter.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative "base_adapter"
+
+module Yabeda
+  # Adapter that discards all metrics. Use when you want to disable metric export
+  # (e.g. in development or when no monitoring backend is configured).
+  class NullAdapter < BaseAdapter
+    def register_counter!(_metric); end
+
+    def perform_counter_increment!(_counter, _tags, _increment); end
+
+    def register_gauge!(_metric); end
+
+    def perform_gauge_set!(_gauge, _tags, _value); end
+
+    def register_histogram!(_metric); end
+
+    def perform_histogram_measure!(_histogram, _tags, _value); end
+
+    def register_summary!(_metric); end
+
+    def perform_summary_observe!(_summary, _tags, _value); end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 require "bundler/setup"
 require "yabeda"
 require "yabeda/base_adapter"
+require "yabeda/test_adapter"
 require "debug"
 
 RSpec.configure do |config|

--- a/spec/yabeda/dsl/class_methods_spec.rb
+++ b/spec/yabeda/dsl/class_methods_spec.rb
@@ -214,4 +214,62 @@ RSpec.describe Yabeda::DSL::ClassMethods do
       end
     end
   end
+
+  describe ".only" do
+    context "when group is not defined" do
+      it "raises an error" do
+        error_message = "Yabeda.only should be called either inside group declaration " \
+          "or should have group name provided. No metric group provided."
+
+        expect do
+          Yabeda.configure { only :test }
+          Yabeda.configure! unless Yabeda.already_configured?
+        end.to raise_error(Yabeda::ConfigurationError, error_message)
+      end
+    end
+
+    context "with a specified group that does not exist" do
+      before do
+        Yabeda.configure { only :test, group: :adapter_group }
+        Yabeda.configure! unless Yabeda.already_configured?
+      end
+
+      it "creates the group" do
+        expect(Yabeda.groups[:adapter_group]).to be_a(Yabeda::Group)
+      end
+
+      it "defines the only list" do
+        expect(Yabeda.groups[:adapter_group].only).to eq(%i[test])
+      end
+    end
+  end
+
+  describe ".except" do
+    context "when group is not defined" do
+      it "raises an error" do
+        error_message = "Yabeda.except should be called either inside group declaration " \
+          "or should have group name provided. No metric group provided."
+
+        expect do
+          Yabeda.configure { except :test }
+          Yabeda.configure! unless Yabeda.already_configured?
+        end.to raise_error(Yabeda::ConfigurationError, error_message)
+      end
+    end
+
+    context "with a specified group that does not exist" do
+      before do
+        Yabeda.configure { except :test, group: :adapter_group }
+        Yabeda.configure! unless Yabeda.already_configured?
+      end
+
+      it "creates the group" do
+        expect(Yabeda.groups[:adapter_group]).to be_a(Yabeda::Group)
+      end
+
+      it "defines the except list" do
+        expect(Yabeda.groups[:adapter_group].except).to eq(%i[test])
+      end
+    end
+  end
 end

--- a/spec/yabeda/group_spec.rb
+++ b/spec/yabeda/group_spec.rb
@@ -29,4 +29,28 @@ RSpec.describe Yabeda::Group do
       end
     end
   end
+
+  describe "only" do
+    it "appends to the only list" do
+      expect(group.only).to be_nil
+
+      group.only :metric1
+      expect(group.only).to eq(%i[metric1])
+
+      group.only :metric2
+      expect(group.only).to eq(%i[metric1 metric2])
+    end
+  end
+
+  describe "except" do
+    it "appends to the except list" do
+      expect(group.except).to be_nil
+      group.except :metric1
+
+      expect(group.except).to eq(%i[metric1])
+      group.except :metric2
+
+      expect(group.except).to eq(%i[metric1 metric2])
+    end
+  end
 end

--- a/spec/yabeda/metric_spec.rb
+++ b/spec/yabeda/metric_spec.rb
@@ -100,6 +100,46 @@ RSpec.describe Yabeda::Metric do
       end
     end
 
+    context "when metric is excluded from group" do
+      let(:options) { { group: :adapter_group } }
+
+      before do
+        Yabeda.configure do
+          group(:adapter_group) { except :some_metric }
+        end
+        Yabeda.configure! unless Yabeda.already_configured?
+      end
+
+      it "returns the null adapter" do
+        aggregate_failures do
+          expect(metric_adapters).to eq({
+                                          null_adapter: ::Yabeda.adapters[:null_adapter],
+                                        })
+          expect(metric_adapters.size).to eq(1)
+        end
+      end
+    end
+
+    context "when metric is included in group" do
+      let(:options) { { group: :adapter_group } }
+
+      before do
+        Yabeda.configure do
+          group(:adapter_group) { only :another_metric }
+        end
+        Yabeda.configure! unless Yabeda.already_configured?
+      end
+
+      it "returns the null adapter" do
+        aggregate_failures do
+          expect(metric_adapters).to eq({
+                                          null_adapter: ::Yabeda.adapters[:null_adapter],
+                                        })
+          expect(metric_adapters.size).to eq(1)
+        end
+      end
+    end
+
     context "when metric has no adapter option but group does" do
       let(:options) { { group: :adapter_group } }
 

--- a/spec/yabeda_spec.rb
+++ b/spec/yabeda_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Yabeda do
 
   it "exposes the public api" do
     expect(described_class.metrics).to eq({})
-    expect(described_class.adapters).to eq({})
+    expect(described_class.adapters).to eq({ null_adapter: ::Yabeda.adapters[:null_adapter] })
     expect(described_class.collectors).to eq([])
     expect(described_class.default_tags).to eq({})
     expect(described_class.configured?).to be(false)


### PR DESCRIPTION
Fixes #48 